### PR TITLE
Fix cargo clippy errors

### DIFF
--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -415,7 +415,7 @@ where
         SigningPackage {
             header: Header::default(),
             signing_commitments,
-            signing_participants_groups: signing_participants_groups,
+            signing_participants_groups,
             message: message.to_vec(),
             adaptor: None,
         }
@@ -431,9 +431,9 @@ where
         SigningPackage {
             header: Header::default(),
             signing_commitments,
-            signing_participants_groups: signing_participants_groups,
+            signing_participants_groups,
             message: message.to_vec(),
-            adaptor: adaptor,
+            adaptor,
         }
     }
 

--- a/frost-core/src/round2.rs
+++ b/frost-core/src/round2.rs
@@ -164,7 +164,7 @@ pub fn sign<C: Ciphersuite>(
         Some(signing_participants_groups) => {
             let mut result: Result<Scalar<C>, Error<C>> = Err(Error::UnknownIdentifier);
             for signing_participants_group in signing_participants_groups {
-                if signing_participants_group.contains(&key_package.identifier()) {
+                if signing_participants_group.contains(key_package.identifier()) {
                     result = frost::compute_lagrange_coefficient(
                         &signing_participants_group,
                         None,

--- a/frost-ed25519/tests/common_traits_tests.rs
+++ b/frost-ed25519/tests/common_traits_tests.rs
@@ -9,7 +9,7 @@ use helpers::samples;
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
     // Make sure can be debug-printed. This also catches if the Debug does not
     // have an endless recursion (a popular mistake).
-    println!("{:?}", v);
+    println!("{v:?}");
     // Test Clone and Eq
     assert_eq!(v, v.clone());
     // Make sure it can be unwrapped in a Result (which requires Debug).

--- a/frost-ed25519/tests/serde_tests.rs
+++ b/frost-ed25519/tests/serde_tests.rs
@@ -19,7 +19,7 @@ fn check_signing_commitments_serialization() {
     let commitments = samples::signing_commitments();
 
     let json = serde_json::to_string_pretty(&commitments).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_commitments: SigningCommitments = serde_json::from_str(&json).unwrap();
     assert!(commitments == decoded_commitments);
@@ -89,7 +89,7 @@ fn check_signing_package_serialization() {
     let signing_package = samples::signing_package();
 
     let json = serde_json::to_string_pretty(&signing_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signing_package: SigningPackage = serde_json::from_str(&json).unwrap();
     assert!(signing_package == decoded_signing_package);
@@ -204,7 +204,7 @@ fn check_signature_share_serialization() {
     let signature_share = samples::signature_share();
 
     let json = serde_json::to_string_pretty(&signature_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signature_share: SignatureShare = serde_json::from_str(&json).unwrap();
     assert!(signature_share == decoded_signature_share);
@@ -258,7 +258,7 @@ fn check_secret_share_serialization() {
     let secret_share = samples::secret_share();
 
     let json = serde_json::to_string_pretty(&secret_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_secret_share: SecretShare = serde_json::from_str(&json).unwrap();
     assert!(secret_share == decoded_secret_share);
@@ -342,7 +342,7 @@ fn check_key_package_serialization() {
     let key_package = samples::key_package();
 
     let json = serde_json::to_string_pretty(&key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_key_package: KeyPackage = serde_json::from_str(&json).unwrap();
     assert!(key_package == decoded_key_package);
@@ -437,7 +437,7 @@ fn check_public_key_package_serialization() {
     let public_key_package = samples::public_key_package_new();
 
     let json = serde_json::to_string_pretty(&public_key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_public_key_package: PublicKeyPackage = serde_json::from_str(&json).unwrap();
     assert!(public_key_package == decoded_public_key_package);
@@ -532,7 +532,7 @@ fn check_round1_package_serialization() {
     let round1_package = samples::round1_package();
 
     let json = serde_json::to_string_pretty(&round1_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round1_package: round1::Package = serde_json::from_str(&json).unwrap();
     assert!(round1_package == decoded_round1_package);
@@ -598,7 +598,7 @@ fn check_round2_package_serialization() {
     let round2_package = samples::round2_package();
 
     let json = serde_json::to_string_pretty(&round2_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round2_package: round2::Package = serde_json::from_str(&json).unwrap();
     assert!(round2_package == decoded_round2_package);

--- a/frost-ed448/tests/common_traits_tests.rs
+++ b/frost-ed448/tests/common_traits_tests.rs
@@ -9,7 +9,7 @@ use helpers::samples;
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
     // Make sure can be debug-printed. This also catches if the Debug does not
     // have an endless recursion (a popular mistake).
-    println!("{:?}", v);
+    println!("{v:?}");
     // Test Clone and Eq
     assert_eq!(v, v.clone());
     // Make sure it can be unwrapped in a Result (which requires Debug).

--- a/frost-ed448/tests/serde_tests.rs
+++ b/frost-ed448/tests/serde_tests.rs
@@ -19,7 +19,7 @@ fn check_signing_commitments_serialization() {
     let commitments = samples::signing_commitments();
 
     let json = serde_json::to_string_pretty(&commitments).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_commitments: SigningCommitments = serde_json::from_str(&json).unwrap();
     assert!(commitments == decoded_commitments);
@@ -89,7 +89,7 @@ fn check_signing_package_serialization() {
     let signing_package = samples::signing_package();
 
     let json = serde_json::to_string_pretty(&signing_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signing_package: SigningPackage = serde_json::from_str(&json).unwrap();
     assert!(signing_package == decoded_signing_package);
@@ -204,7 +204,7 @@ fn check_signature_share_serialization() {
     let signature_share = samples::signature_share();
 
     let json = serde_json::to_string_pretty(&signature_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signature_share: SignatureShare = serde_json::from_str(&json).unwrap();
     assert!(signature_share == decoded_signature_share);
@@ -258,7 +258,7 @@ fn check_secret_share_serialization() {
     let secret_share = samples::secret_share();
 
     let json = serde_json::to_string_pretty(&secret_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_secret_share: SecretShare = serde_json::from_str(&json).unwrap();
     assert!(secret_share == decoded_secret_share);
@@ -342,7 +342,7 @@ fn check_key_package_serialization() {
     let key_package = samples::key_package();
 
     let json = serde_json::to_string_pretty(&key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_key_package: KeyPackage = serde_json::from_str(&json).unwrap();
     assert!(key_package == decoded_key_package);
@@ -437,7 +437,7 @@ fn check_public_key_package_serialization() {
     let public_key_package = samples::public_key_package_new();
 
     let json = serde_json::to_string_pretty(&public_key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_public_key_package: PublicKeyPackage = serde_json::from_str(&json).unwrap();
     assert!(public_key_package == decoded_public_key_package);
@@ -532,7 +532,7 @@ fn check_round1_package_serialization() {
     let round1_package = samples::round1_package();
 
     let json = serde_json::to_string_pretty(&round1_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round1_package: round1::Package = serde_json::from_str(&json).unwrap();
     assert!(round1_package == decoded_round1_package);
@@ -598,7 +598,7 @@ fn check_round2_package_serialization() {
     let round2_package = samples::round2_package();
 
     let json = serde_json::to_string_pretty(&round2_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round2_package: round2::Package = serde_json::from_str(&json).unwrap();
     assert!(round2_package == decoded_round2_package);

--- a/frost-p256/tests/common_traits_tests.rs
+++ b/frost-p256/tests/common_traits_tests.rs
@@ -9,7 +9,7 @@ use helpers::samples;
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
     // Make sure can be debug-printed. This also catches if the Debug does not
     // have an endless recursion (a popular mistake).
-    println!("{:?}", v);
+    println!("{v:?}");
     // Test Clone and Eq
     assert_eq!(v, v.clone());
     // Make sure it can be unwrapped in a Result (which requires Debug).

--- a/frost-p256/tests/serde_tests.rs
+++ b/frost-p256/tests/serde_tests.rs
@@ -19,7 +19,7 @@ fn check_signing_commitments_serialization() {
     let commitments = samples::signing_commitments();
 
     let json = serde_json::to_string_pretty(&commitments).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_commitments: SigningCommitments = serde_json::from_str(&json).unwrap();
     assert!(commitments == decoded_commitments);
@@ -89,7 +89,7 @@ fn check_signing_package_serialization() {
     let signing_package = samples::signing_package();
 
     let json = serde_json::to_string_pretty(&signing_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signing_package: SigningPackage = serde_json::from_str(&json).unwrap();
     assert!(signing_package == decoded_signing_package);
@@ -204,7 +204,7 @@ fn check_signature_share_serialization() {
     let signature_share = samples::signature_share();
 
     let json = serde_json::to_string_pretty(&signature_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signature_share: SignatureShare = serde_json::from_str(&json).unwrap();
     assert!(signature_share == decoded_signature_share);
@@ -258,7 +258,7 @@ fn check_secret_share_serialization() {
     let secret_share = samples::secret_share();
 
     let json = serde_json::to_string_pretty(&secret_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_secret_share: SecretShare = serde_json::from_str(&json).unwrap();
     assert!(secret_share == decoded_secret_share);
@@ -342,7 +342,7 @@ fn check_key_package_serialization() {
     let key_package = samples::key_package();
 
     let json = serde_json::to_string_pretty(&key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_key_package: KeyPackage = serde_json::from_str(&json).unwrap();
     assert!(key_package == decoded_key_package);
@@ -437,7 +437,7 @@ fn check_public_key_package_serialization() {
     let public_key_package = samples::public_key_package_new();
 
     let json = serde_json::to_string_pretty(&public_key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_public_key_package: PublicKeyPackage = serde_json::from_str(&json).unwrap();
     assert!(public_key_package == decoded_public_key_package);
@@ -532,7 +532,7 @@ fn check_round1_package_serialization() {
     let round1_package = samples::round1_package();
 
     let json = serde_json::to_string_pretty(&round1_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round1_package: round1::Package = serde_json::from_str(&json).unwrap();
     assert!(round1_package == decoded_round1_package);
@@ -598,7 +598,7 @@ fn check_round2_package_serialization() {
     let round2_package = samples::round2_package();
 
     let json = serde_json::to_string_pretty(&round2_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round2_package: round2::Package = serde_json::from_str(&json).unwrap();
     assert!(round2_package == decoded_round2_package);

--- a/frost-ristretto255/tests/common_traits_tests.rs
+++ b/frost-ristretto255/tests/common_traits_tests.rs
@@ -9,7 +9,7 @@ use helpers::samples;
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
     // Make sure can be debug-printed. This also catches if the Debug does not
     // have an endless recursion (a popular mistake).
-    println!("{:?}", v);
+    println!("{v:?}");
     // Test Clone and Eq
     assert_eq!(v, v.clone());
     // Make sure it can be unwrapped in a Result (which requires Debug).

--- a/frost-ristretto255/tests/serde_tests.rs
+++ b/frost-ristretto255/tests/serde_tests.rs
@@ -19,7 +19,7 @@ fn check_signing_commitments_serialization() {
     let commitments = samples::signing_commitments();
 
     let json = serde_json::to_string_pretty(&commitments).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_commitments: SigningCommitments = serde_json::from_str(&json).unwrap();
     assert!(commitments == decoded_commitments);
@@ -89,7 +89,7 @@ fn check_signing_package_serialization() {
     let signing_package = samples::signing_package();
 
     let json = serde_json::to_string_pretty(&signing_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signing_package: SigningPackage = serde_json::from_str(&json).unwrap();
     assert!(signing_package == decoded_signing_package);
@@ -204,7 +204,7 @@ fn check_signature_share_serialization() {
     let signature_share = samples::signature_share();
 
     let json = serde_json::to_string_pretty(&signature_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signature_share: SignatureShare = serde_json::from_str(&json).unwrap();
     assert!(signature_share == decoded_signature_share);
@@ -258,7 +258,7 @@ fn check_secret_share_serialization() {
     let secret_share = samples::secret_share();
 
     let json = serde_json::to_string_pretty(&secret_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_secret_share: SecretShare = serde_json::from_str(&json).unwrap();
     assert!(secret_share == decoded_secret_share);
@@ -342,7 +342,7 @@ fn check_key_package_serialization() {
     let key_package = samples::key_package();
 
     let json = serde_json::to_string_pretty(&key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_key_package: KeyPackage = serde_json::from_str(&json).unwrap();
     assert!(key_package == decoded_key_package);
@@ -437,7 +437,7 @@ fn check_public_key_package_serialization() {
     let public_key_package = samples::public_key_package_new();
 
     let json = serde_json::to_string_pretty(&public_key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_public_key_package: PublicKeyPackage = serde_json::from_str(&json).unwrap();
     assert!(public_key_package == decoded_public_key_package);
@@ -532,7 +532,7 @@ fn check_round1_package_serialization() {
     let round1_package = samples::round1_package();
 
     let json = serde_json::to_string_pretty(&round1_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round1_package: round1::Package = serde_json::from_str(&json).unwrap();
     assert!(round1_package == decoded_round1_package);
@@ -598,7 +598,7 @@ fn check_round2_package_serialization() {
     let round2_package = samples::round2_package();
 
     let json = serde_json::to_string_pretty(&round2_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round2_package: round2::Package = serde_json::from_str(&json).unwrap();
     assert!(round2_package == decoded_round2_package);

--- a/frost-secp256k1-tr/tests/common_traits_tests.rs
+++ b/frost-secp256k1-tr/tests/common_traits_tests.rs
@@ -9,7 +9,7 @@ use helpers::samples;
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
     // Make sure can be debug-printed. This also catches if the Debug does not
     // have an endless recursion (a popular mistake).
-    println!("{:?}", v);
+    println!("{v:?}");
     // Test Clone and Eq
     assert_eq!(v, v.clone());
     // Make sure it can be unwrapped in a Result (which requires Debug).

--- a/frost-secp256k1-tr/tests/serde_tests.rs
+++ b/frost-secp256k1-tr/tests/serde_tests.rs
@@ -19,7 +19,7 @@ fn check_signing_commitments_serialization() {
     let commitments = samples::signing_commitments();
 
     let json = serde_json::to_string_pretty(&commitments).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_commitments: SigningCommitments = serde_json::from_str(&json).unwrap();
     assert!(commitments == decoded_commitments);
@@ -89,7 +89,7 @@ fn check_signing_package_serialization() {
     let signing_package = samples::signing_package();
 
     let json = serde_json::to_string_pretty(&signing_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signing_package: SigningPackage = serde_json::from_str(&json).unwrap();
     assert!(signing_package == decoded_signing_package);
@@ -204,7 +204,7 @@ fn check_signature_share_serialization() {
     let signature_share = samples::signature_share();
 
     let json = serde_json::to_string_pretty(&signature_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signature_share: SignatureShare = serde_json::from_str(&json).unwrap();
     assert!(signature_share == decoded_signature_share);
@@ -258,7 +258,7 @@ fn check_secret_share_serialization() {
     let secret_share = samples::secret_share();
 
     let json = serde_json::to_string_pretty(&secret_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_secret_share: SecretShare = serde_json::from_str(&json).unwrap();
     assert!(secret_share == decoded_secret_share);
@@ -342,7 +342,7 @@ fn check_key_package_serialization() {
     let key_package = samples::key_package();
 
     let json = serde_json::to_string_pretty(&key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_key_package: KeyPackage = serde_json::from_str(&json).unwrap();
     assert!(key_package == decoded_key_package);
@@ -437,7 +437,7 @@ fn check_public_key_package_serialization() {
     let public_key_package = samples::public_key_package_new();
 
     let json = serde_json::to_string_pretty(&public_key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_public_key_package: PublicKeyPackage = serde_json::from_str(&json).unwrap();
     assert!(public_key_package == decoded_public_key_package);
@@ -532,7 +532,7 @@ fn check_round1_package_serialization() {
     let round1_package = samples::round1_package();
 
     let json = serde_json::to_string_pretty(&round1_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round1_package: round1::Package = serde_json::from_str(&json).unwrap();
     assert!(round1_package == decoded_round1_package);
@@ -598,7 +598,7 @@ fn check_round2_package_serialization() {
     let round2_package = samples::round2_package();
 
     let json = serde_json::to_string_pretty(&round2_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round2_package: round2::Package = serde_json::from_str(&json).unwrap();
     assert!(round2_package == decoded_round2_package);

--- a/frost-secp256k1/tests/common_traits_tests.rs
+++ b/frost-secp256k1/tests/common_traits_tests.rs
@@ -9,7 +9,7 @@ use helpers::samples;
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
     // Make sure can be debug-printed. This also catches if the Debug does not
     // have an endless recursion (a popular mistake).
-    println!("{:?}", v);
+    println!("{v:?}");
     // Test Clone and Eq
     assert_eq!(v, v.clone());
     // Make sure it can be unwrapped in a Result (which requires Debug).

--- a/frost-secp256k1/tests/serde_tests.rs
+++ b/frost-secp256k1/tests/serde_tests.rs
@@ -19,7 +19,7 @@ fn check_signing_commitments_serialization() {
     let commitments = samples::signing_commitments();
 
     let json = serde_json::to_string_pretty(&commitments).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_commitments: SigningCommitments = serde_json::from_str(&json).unwrap();
     assert!(commitments == decoded_commitments);
@@ -89,7 +89,7 @@ fn check_signing_package_serialization() {
     let signing_package = samples::signing_package();
 
     let json = serde_json::to_string_pretty(&signing_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signing_package: SigningPackage = serde_json::from_str(&json).unwrap();
     assert!(signing_package == decoded_signing_package);
@@ -204,7 +204,7 @@ fn check_signature_share_serialization() {
     let signature_share = samples::signature_share();
 
     let json = serde_json::to_string_pretty(&signature_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_signature_share: SignatureShare = serde_json::from_str(&json).unwrap();
     assert!(signature_share == decoded_signature_share);
@@ -258,7 +258,7 @@ fn check_secret_share_serialization() {
     let secret_share = samples::secret_share();
 
     let json = serde_json::to_string_pretty(&secret_share).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_secret_share: SecretShare = serde_json::from_str(&json).unwrap();
     assert!(secret_share == decoded_secret_share);
@@ -342,7 +342,7 @@ fn check_key_package_serialization() {
     let key_package = samples::key_package();
 
     let json = serde_json::to_string_pretty(&key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_key_package: KeyPackage = serde_json::from_str(&json).unwrap();
     assert!(key_package == decoded_key_package);
@@ -437,7 +437,7 @@ fn check_public_key_package_serialization() {
     let public_key_package = samples::public_key_package_new();
 
     let json = serde_json::to_string_pretty(&public_key_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_public_key_package: PublicKeyPackage = serde_json::from_str(&json).unwrap();
     assert!(public_key_package == decoded_public_key_package);
@@ -532,7 +532,7 @@ fn check_round1_package_serialization() {
     let round1_package = samples::round1_package();
 
     let json = serde_json::to_string_pretty(&round1_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round1_package: round1::Package = serde_json::from_str(&json).unwrap();
     assert!(round1_package == decoded_round1_package);
@@ -598,7 +598,7 @@ fn check_round2_package_serialization() {
     let round2_package = samples::round2_package();
 
     let json = serde_json::to_string_pretty(&round2_package).unwrap();
-    println!("{}", json);
+    println!("{json}");
 
     let decoded_round2_package: round2::Package = serde_json::from_str(&json).unwrap();
     assert!(round2_package == decoded_round2_package);

--- a/gencode/src/main.rs
+++ b/gencode/src/main.rs
@@ -124,8 +124,7 @@ fn write_docs(
         let new_doc = docs.get(old_name).map(|v| v.1.clone());
         let Some(new_doc) = new_doc else {
             eprintln!(
-                "WARNING: documentation for {} is not available in base file. This can mean it's a specific type for the ciphersuite, or that there is a bug in gencode",
-                old_name
+                "WARNING: documentation for {old_name} is not available in base file. This can mean it's a specific type for the ciphersuite, or that there is a bug in gencode"
             );
             continue;
         };


### PR DESCRIPTION
Fix linting errors detected by `cargo clippy`, e.g. [here](https://github.com/lightsparkdev/frost/actions/runs/25526826564/job/74924248860)